### PR TITLE
Bug fix assert not found

### DIFF
--- a/bin/config/base_config.js
+++ b/bin/config/base_config.js
@@ -1,4 +1,4 @@
-import packageJSON from "../../package.json" assert { type: "json" }
+import packageJSON from "../../package.json" with { type: "json" }
 
 const PACKAGE_NAME = packageJSON.name
 const PACKAGE_VERSION = packageJSON.version

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,4 +1,4 @@
-import packageJSON from "../package.json" assert { type: "json" }
+import packageJSON from "../package.json" with { type: "json" }
 import { JuicyLogsBaseConfig } from "./config.js"
 import ConfiguredLogger from "./logs/configured_logger.js"
 import EventPusher from "./events/event_pusher.js"

--- a/bin/logs/logger.js
+++ b/bin/logs/logger.js
@@ -35,8 +35,9 @@ class Log {
 }
 
 export default class Logger {
+  baseConfigClass = JuicyLogsBaseConfig
   constructor(configOverrides) {
-    this.config = new JuicyLogsBaseConfig(configOverrides)
+    this.config = new this.baseConfigClass(configOverrides)
   }
 
   static async sendLog(config, data) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juicyjah/juicy-logs-kit-core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Logging tool for sending app logs and events to Juicy Logs from JavaScript",
   "type": "module",
   "main": "bin/index.js",


### PR DESCRIPTION
Fix a bug in the usage of the package where nodejs does not recognize `assert` but recognizes `with` for JSON module imports

The current implementation works for some instances of vite, but non-vite servers would have issues.

